### PR TITLE
Feature/issue 59/prepare aws deployment

### DIFF
--- a/.ebextensions/01_django.config
+++ b/.ebextensions/01_django.config
@@ -1,0 +1,6 @@
+option_settings:
+  aws:elasticbeanstalk:application:environment:
+    DJANGO_SETTINGS_MODULE: "src.django_management.settings"
+    PYTHONPATH: "/var/app/current:$PYTHONPATH"
+  aws:elasticbeanstalk:container:python:
+    WSGIPath: "src.django_management.wsgi:application"

--- a/.ebextensions/01_django.config
+++ b/.ebextensions/01_django.config
@@ -5,4 +5,4 @@ option_settings:
   aws:elasticbeanstalk:container:python:
     WSGIPath: "src.django_management.wsgi:application"
   aws:elasticbeanstalk:environment:proxy:staticfiles:
-    /static: "src.static"
+    /static: "src/static"

--- a/.ebextensions/01_django.config
+++ b/.ebextensions/01_django.config
@@ -5,4 +5,4 @@ option_settings:
   aws:elasticbeanstalk:container:python:
     WSGIPath: "src.django_management.wsgi:application"
   aws:elasticbeanstalk:environment:proxy:staticfiles:
-    /static: static
+    /static: staticfiles

--- a/.ebextensions/01_django.config
+++ b/.ebextensions/01_django.config
@@ -5,4 +5,4 @@ option_settings:
   aws:elasticbeanstalk:container:python:
     WSGIPath: "src.django_management.wsgi:application"
   aws:elasticbeanstalk:environment:proxy:staticfiles:
-    /static: staticfiles
+    /static: "src.static"

--- a/.ebextensions/01_django.config
+++ b/.ebextensions/01_django.config
@@ -1,6 +1,6 @@
 option_settings:
   aws:elasticbeanstalk:application:environment:
     DJANGO_SETTINGS_MODULE: "src.django_management.settings"
-    PYTHONPATH: "/var/app/current:$PYTHONPATH"
+    PYTHONPATH: "/var/app/current/src:$PYTHONPATH"
   aws:elasticbeanstalk:container:python:
     WSGIPath: "src.django_management.wsgi:application"

--- a/.ebextensions/01_django.config
+++ b/.ebextensions/01_django.config
@@ -4,3 +4,5 @@ option_settings:
     PYTHONPATH: "/var/app/current/src:$PYTHONPATH"
   aws:elasticbeanstalk:container:python:
     WSGIPath: "src.django_management.wsgi:application"
+  aws:elasticbeanstalk:environment:proxy:staticfiles:
+    /static: static

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ db.sqlite3
 
 # Mac OS
 .DS_Store
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ db.sqlite3
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+# Static
+staticfiles/

--- a/src/django_management/settings.py
+++ b/src/django_management/settings.py
@@ -26,7 +26,9 @@ SECRET_KEY = 'django-insecure-bydqct==mg#ii(79dn!=t77we%@1lw+m!fmdxueqo&*nqc_#53
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['food-donation-swe-dev.us-east-1.elasticbeanstalk.com', '127.0.0.1', 'localhost']
+ALLOWED_HOSTS = ['food-donation-swe-dev.us-east-1.elasticbeanstalk.com',
+                 '127.0.0.1',
+                 'localhost']
 
 # Application definition
 

--- a/src/django_management/settings.py
+++ b/src/django_management/settings.py
@@ -120,8 +120,8 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = '/static/'
 
-# Define the location where static files will be collected
-STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+# # Define the location where static files will be collected
+# STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 # Additional locations for static files
 STATICFILES_DIRS = [

--- a/src/django_management/settings.py
+++ b/src/django_management/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -116,8 +117,16 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
-STATIC_URL = 'static/'
-STATICFILES_DIRS = [BASE_DIR / "static"]
+# Static files (CSS, JavaScript, Images)
+STATIC_URL = '/static/'
+
+# Define the location where static files will be collected
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
+# Additional locations for static files
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'static'),
+]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field

--- a/src/django_management/settings.py
+++ b/src/django_management/settings.py
@@ -119,13 +119,11 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
-# Static files (CSS, JavaScript, Images)
+# Static files (CSS, JavaScript, Images).
+# This is where the browser will serve.
 STATIC_URL = '/static/'
 
-# # Define the location where static files will be collected
-# STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
-
-# Additional locations for static files
+# Additional locations for static files in our repository
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'static'),
 ]

--- a/src/django_management/settings.py
+++ b/src/django_management/settings.py
@@ -37,7 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     #other apps
-    'accounts',
+    'accounts.apps.AccountsConfig'
 ]
 
 MIDDLEWARE = [

--- a/src/django_management/settings.py
+++ b/src/django_management/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-bydqct==mg#ii(79dn!=t77we%@1lw+m!fmdxueqo&*nqc_#53
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['http://food-donation-swe-dev.us-east-1.elasticbeanstalk.com', '127.0.0.1', 'localhost']
+ALLOWED_HOSTS = ['food-donation-swe-dev.us-east-1.elasticbeanstalk.com', '127.0.0.1', 'localhost']
 
 # Application definition
 
@@ -36,7 +36,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    #other apps
+    # Our sub applications
     'accounts.apps.AccountsConfig'
 ]
 

--- a/src/django_management/settings.py
+++ b/src/django_management/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-bydqct==mg#ii(79dn!=t77we%@1lw+m!fmdxueqo&*nqc_#53
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['http://food-donation-swe-dev.us-east-1.elasticbeanstalk.com', '127.0.0.1', 'localhost']
 
 # Application definition
 


### PR DESCRIPTION
# [Issue 59](https://github.com/gcivil-nyu-org/wed-fall24-team5/issues)

## Description

- Adds code to deploy to Elastic Beanstalk
- Serves the `static` files to ensure CSS
- It's tied to my AWS Account now, but I'll look into how we can setup getting everyone's accounts access to the environment.
- Deployed to: http://food-donation-swe-dev.us-east-1.elasticbeanstalk.com/

## Change Type (delete non-relevant options)

- 💡 New feature (non-breaking change which adds functionality)

## Dependencies

- I will explain the deploy process this week. Right now, it is manual, but Anthony said we'll be setting up CI/CD pipelines in class this week.
