### PR TITLE
Chore/issue 98/deploy to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,5 +197,5 @@ coverage run --source='src' src/manage.py test
 
 - This application is set up for deployment using AWS Elastic Beanstalk.
 - Deployment is handled using Travis CI. Deployments are automatic on pushes to the `main` branch or the `develop` branch
-- The `develop` branch deploys [here](http://food-donation-swe-dev.us-east-1.elasticbeanstalk.com).
-- The `main` branch is currently undeployed.
+- The `develop` branch deploys [here](fooddonation-dev.com).
+- The `main` branch deploys [here](fooddonation-prod.com).

--- a/src/django_management/settings.py
+++ b/src/django_management/settings.py
@@ -207,7 +207,8 @@ ACCOUNT_EMAIL_VERIFICATION = "none"
 
 ### HTTPS Setups ###
 # Redirect HTTP to HTTPS
-SECURE_SSL_REDIRECT = True
+# To allow local development to not redirect to HTTPS. Default to HTTPS
+SECURE_SSL_REDIRECT = (os.getenv("SSL_REDIRECT", "True") == "True")
 # Enforce HTTP Strict Transport Security (HSTS) for 1 year
 SECURE_HSTS_SECONDS = 31536000
 # Allow site to be included in browsers' HSTS preload lists

--- a/src/django_management/settings.py
+++ b/src/django_management/settings.py
@@ -205,10 +205,10 @@ ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_USERNAME_REQUIRED = False
 ACCOUNT_EMAIL_VERIFICATION = "none"
 
-### HTTPS Setups ###
+# ******** HTTPS Setups ********#
 # Redirect HTTP to HTTPS
 # To allow local development to not redirect to HTTPS. Default to HTTPS
-SECURE_SSL_REDIRECT = (os.getenv("SSL_REDIRECT", "True") == "True")
+SECURE_SSL_REDIRECT = os.getenv("SSL_REDIRECT", "True") == "True"
 # Enforce HTTP Strict Transport Security (HSTS) for 1 year
 SECURE_HSTS_SECONDS = 31536000
 # Allow site to be included in browsers' HSTS preload lists

--- a/src/django_management/settings.py
+++ b/src/django_management/settings.py
@@ -27,7 +27,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 
 # Load DEBUG from environment variables, default to False if not set
-DEBUG = True
+DEBUG = os.getenv("DJANGO_DEBUG", "False") == "True"
 
 ALLOWED_HOSTS = [
     "food-donation-swe-dev.us-east-1.elasticbeanstalk.com",

--- a/src/django_management/settings.py
+++ b/src/django_management/settings.py
@@ -31,6 +31,9 @@ DEBUG = True
 
 ALLOWED_HOSTS = [
     "food-donation-swe-dev.us-east-1.elasticbeanstalk.com",
+    "food-donation-swe-prod.us-east-1.elasticbeanstalk.com",
+    "fooddonation-dev.com",
+    "fooddonation-prod.com",
     "172.31.30.180",  # PostGres
     "34.202.22.62",  # PostGres
     "127.0.0.1",
@@ -201,3 +204,13 @@ ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_USERNAME_REQUIRED = False
 ACCOUNT_EMAIL_VERIFICATION = "none"
+
+### HTTPS Setups ###
+# Redirect HTTP to HTTPS
+SECURE_SSL_REDIRECT = True
+# Enforce HTTP Strict Transport Security (HSTS) for 1 year
+SECURE_HSTS_SECONDS = 31536000
+# Allow site to be included in browsers' HSTS preload lists
+SECURE_HSTS_PRELOAD = True
+# Apply HSTS to all subdomains
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True


### PR DESCRIPTION
# [Issue 98](https://github.com/gcivil-nyu-org/wed-fall24-team5/issues/98)

## Description

- Set up two URLs with AWS Route 53
- Set up AWS Certificates for the URLS
- Add listener to the application's load balancer for port 443 (HTTPS)
- Add new urls to the application allowed hosts
- Add required HTTPS redirection to the site.

## Change Type (delete non-relevant options)

- 🧹 Chore (maintenance tasks that don't add new features or fix bugs)

## Dependencies

- Requires you to add `SSL_REDIRECT = 'FALSE'` to your `.env` file
