### PR TITLE
Implement Reserve Donation

### DIFF
--- a/src/recipient_dashboard/templates/recipient_dashboard/dashboard.html
+++ b/src/recipient_dashboard/templates/recipient_dashboard/dashboard.html
@@ -42,7 +42,8 @@
                                 </div>
                             </div>
                             <footer class="card-footer">
-                                <a href="#" class="card-footer-item">Reserve</a>
+                                <a href="{% url 'reserve_donation' donation.donation_id %}"
+                                   class="card-footer-item">Reserve</a>
                             </footer>
                         </div>
                     </div>

--- a/src/recipient_dashboard/templates/recipient_dashboard/dashboard.html
+++ b/src/recipient_dashboard/templates/recipient_dashboard/dashboard.html
@@ -4,6 +4,19 @@
 {% endblock title %}
 {% block content %}
     <div class="container">
+
+        <!-- Notification -->
+        {% if messages %}
+            <div id="notification-area" style="position: absolute; top: 5px; right: 5px; z-index: 1000;">
+                {% for message in messages %}
+                    <div class="notification is-{{ message.tags }}" style="width: auto; padding-right: 2.5rem;">
+                        <button class="delete" style="position: absolute; right: 10px;"></button>
+                        {{ message }}
+                    </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+
         <h1 class="title">Welcome, {{ user.first_name }} {{ user.last_name }}!</h1>
         <h2 class="subtitle mt-3">List of Available Donations:</h2>
         {% if donations %}
@@ -53,4 +66,23 @@
             <p class="box">No donations available at the moment.</p>
         {% endif %}
     </div>
+    <script>
+        // Auto-dismiss notification after 10 seconds
+        document.addEventListener('DOMContentLoaded', () => {
+            const notifications = document.querySelectorAll('.notification');
+            notifications.forEach(notification => {
+                setTimeout(() => {
+                    notification.style.display = 'none';
+                }, 10000);
+            });
+
+            // Enable close button on notification
+            const closeButtons = document.querySelectorAll('.delete');
+            closeButtons.forEach(button => {
+                button.addEventListener('click', () => {
+                    button.parentElement.style.display = 'none';
+                });
+            });
+        });
+    </script>
 {% endblock content %}

--- a/src/recipient_dashboard/templates/recipient_dashboard/dashboard.html
+++ b/src/recipient_dashboard/templates/recipient_dashboard/dashboard.html
@@ -7,10 +7,12 @@
 
         <!-- Notification -->
         {% if messages %}
+        <!-- djlint:off --> 
             <div id="notification-area" style="position: absolute; top: 5px; right: 5px; z-index: 1000;">
                 {% for message in messages %}
                     <div class="notification is-{{ message.tags }}" style="width: auto; padding-right: 2.5rem;">
                         <button class="delete" style="position: absolute; right: 10px;"></button>
+                    <!-- djlint:on -->
                         {{ message }}
                     </div>
                 {% endfor %}

--- a/src/recipient_dashboard/tests.py
+++ b/src/recipient_dashboard/tests.py
@@ -2,86 +2,87 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 from database.models import Donation, Organization, Order
-from django.utils import timezone # for pickup date being tomorrow in tests
-from datetime import timedelta # for pickup date being tomorrow in tests
+from django.utils import timezone  # for pickup date being tomorrow in tests
+from datetime import timedelta  # for pickup date being tomorrow in tests
 from django.contrib.messages import get_messages  # to capture messages
 from django.contrib.sites.models import Site
 from allauth.socialaccount.models import SocialApp
 
-# class RecipientDashboardViewTests(TestCase):
-#     def setUp(self):
-#         # Creating a dummy user for testing
-#         User = get_user_model()
-#         self.user = User.objects.create_user(username="testuser", password="testpass")
+class RecipientDashboardViewTests(TestCase):
+    def setUp(self):
+        # Creating a dummy user for testing
+        User = get_user_model()
+        self.user = User.objects.create_user(username="testuser", password="testpass")
 
-#         # Logging in the user
-#         self.client.login(username="testuser", password="testpass")
+        # Logging in the user
+        self.client.login(username="testuser", password="testpass")
 
-#         # Create an organization for donations
-#         self.organization = Organization.objects.create(
-#             organization_name="Team 5 Test Organization",
-#             type="restaurant",
-#             address="123 Test St",
-#             zipcode=12345,
-#             contact_number="1234567890",
-#             email="test@example.com",
-#             website="http://test.org",
-#             active=True,
-#         )
+        # Create an organization for donations
+        self.organization = Organization.objects.create(
+            organization_name="Team 5 Test Organization",
+            type="restaurant",
+            address="123 Test St",
+            zipcode=12345,
+            contact_number="1234567890",
+            email="test@example.com",
+            website="http://test.org",
+            active=True,
+        )
 
-#         # Create active donations for testing
-#         self.donation1 = Donation.objects.create(
-#             organization_id=self.organization,
-#             food_item="Biryani",
-#             quantity=10,
-#             pickup_by="2024-10-15",
-#             active=True,
-#         )
-#         self.donation2 = Donation.objects.create(
-#             organization_id=self.organization,
-#             food_item="Shawarma",
-#             quantity=5,
-#             pickup_by="2024-10-15",
-#             active=True,
-#         )
+        # Create active donations for testing
+        self.donation1 = Donation.objects.create(
+            organization_id=self.organization,
+            food_item="Biryani",
+            quantity=10,
+            pickup_by="2024-10-15",
+            active=True,
+        )
+        self.donation2 = Donation.objects.create(
+            organization_id=self.organization,
+            food_item="Shawarma",
+            quantity=5,
+            pickup_by="2024-10-15",
+            active=True,
+        )
 
-#     def test_recipient_dashboard_status_code(self):
-#         """
-#         Test that the recipient dashboard view returns a 200 OK status.
-#         """
-#         response = self.client.get(reverse("recipient_dashboard"))
-#         self.assertEqual(response.status_code, 200)
+    def test_recipient_dashboard_status_code(self):
+        """
+        Test that the recipient dashboard view returns a 200 OK status.
+        """
+        response = self.client.get(reverse("recipient_dashboard"))
+        self.assertEqual(response.status_code, 200)
 
-#     def test_recipient_dashboard_template_used(self):
-#         """
-#         Test that the correct template is used for the recipient dashboard.
-#         """
-#         response = self.client.get(reverse("recipient_dashboard"))
-#         self.assertTemplateUsed(response, "recipient_dashboard/dashboard.html")
+    def test_recipient_dashboard_template_used(self):
+        """
+        Test that the correct template is used for the recipient dashboard.
+        """
+        response = self.client.get(reverse("recipient_dashboard"))
+        self.assertTemplateUsed(response, "recipient_dashboard/dashboard.html")
 
-#     def test_recipient_dashboard_active_donations(self):
-#         """
-#         Test that the context contains only active donations.
-#         """
-#         response = self.client.get(reverse("recipient_dashboard"))
-#         self.assertIn("donations", response.context)
-#         self.assertEqual(
-#             len(response.context["donations"]), 2
-#         )  # Should include 2 active donations
+    def test_recipient_dashboard_active_donations(self):
+        """
+        Test that the context contains only active donations.
+        """
+        response = self.client.get(reverse("recipient_dashboard"))
+        self.assertIn("donations", response.context)
+        self.assertEqual(
+            len(response.context["donations"]), 2
+        )  # Should include 2 active donations
 
-#     def test_recipient_dashboard_donations_content(self):
-#         """
-#         Test that the donations returned are as expected.
-#         """
-#         response = self.client.get(reverse("recipient_dashboard"))
-#         donation_items = [
-#             donation.food_item for donation in response.context["donations"]
-#         ]
-#         self.assertIn("Biryani", donation_items)
-#         self.assertIn("Shawarma", donation_items)
-#         self.assertNotIn(
-#             "Pasta", donation_items
-#         )  # Checking if a non-listed item is checked or not
+    def test_recipient_dashboard_donations_content(self):
+        """
+        Test that the donations returned are as expected.
+        """
+        response = self.client.get(reverse("recipient_dashboard"))
+        donation_items = [
+            donation.food_item for donation in response.context["donations"]
+        ]
+        self.assertIn("Biryani", donation_items)
+        self.assertIn("Shawarma", donation_items)
+        self.assertNotIn(
+            "Pasta", donation_items
+        )  # Checking if a non-listed item is checked or not
+
 
 class ReserveDonationTest(TestCase):
 
@@ -92,7 +93,7 @@ class ReserveDonationTest(TestCase):
 
         # Logging in the user
         self.client.login(username="testuser", password="testpass")
-        
+
         # Create an organization
         self.organization = Organization.objects.create(
             organization_name="Test Organization",
@@ -101,38 +102,42 @@ class ReserveDonationTest(TestCase):
             zipcode=12345,
             contact_number="1234567890",
             email="test@example.com",
-            active=True
+            active=True,
         )
-        
+
         # Create a donation
         self.donation = Donation.objects.create(
             organization=self.organization,
             food_item="Test Food",
             quantity=5,
             pickup_by=timezone.now() + timedelta(days=1),
-            active=True
+            active=True,
         )
 
         # Set up SocialApp for allauth (required for login redirection)
         site = Site.objects.get_current()
         self.social_app = SocialApp.objects.create(
-            provider='google',
-            name='Test Google App',
-            client_id='test-client-id',
-            secret='test-secret',
+            provider="google",
+            name="Test Google App",
+            client_id="test-client-id",
+            secret="test-secret",
         )
         self.social_app.sites.add(site)
 
     def test_reserve_donation_success(self):
         """Test a successful donation reservation."""
-        response = self.client.get(reverse('reserve_donation', args=[self.donation.donation_id]))
+        response = self.client.get(
+            reverse("reserve_donation", args=[self.donation.donation_id])
+        )
 
         # Check if the reservation was successful
         self.assertEqual(response.status_code, 302)  # Redirect after success
-        self.assertRedirects(response, reverse('recipient_dashboard'))
+        self.assertRedirects(response, reverse("recipient_dashboard"))
 
         # Check if the order was created
-        order = Order.objects.filter(user=self.user, donation=self.donation, order_status='pending').first()
+        order = Order.objects.filter(
+            user=self.user, donation=self.donation, order_status="pending"
+        ).first()
         self.assertIsNotNone(order)
         self.assertEqual(order.order_quantity, 1)
 
@@ -150,11 +155,13 @@ class ReserveDonationTest(TestCase):
         self.donation.quantity = 0
         self.donation.save()
 
-        response = self.client.get(reverse('reserve_donation', args=[self.donation.donation_id]))
+        response = self.client.get(
+            reverse("reserve_donation", args=[self.donation.donation_id])
+        )
 
         # Check if it redirects back
         self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, reverse('recipient_dashboard'))
+        self.assertRedirects(response, reverse("recipient_dashboard"))
 
         # Ensure no order was created
         order = Order.objects.filter(user=self.user, donation=self.donation).first()
@@ -168,36 +175,49 @@ class ReserveDonationTest(TestCase):
     def test_reserve_donation_not_logged_in(self):
         """Test that a user must be logged in to reserve a donation."""
         self.client.logout()
-        response = self.client.get(reverse('reserve_donation', args=[self.donation.donation_id]))
+        response = self.client.get(
+            reverse("reserve_donation", args=[self.donation.donation_id])
+        )
 
         # Ensure user is redirected to the login page
         self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, f'/accounts/login/?next=/recipient_dashboard/reserve/{self.donation.donation_id}/')
-    
+        self.assertRedirects(
+            response,
+            f"/accounts/login/?next=/recipient_dashboard/reserve/{self.donation.donation_id}/",
+        )
+
     def test_reserve_donation_increment_quantity(self):
         """Test that reserving an existing donation increments the order quantity."""
         # Reserve the donation for the first time
-        self.client.get(reverse('reserve_donation', args=[self.donation.donation_id]))
+        self.client.get(reverse("reserve_donation", args=[self.donation.donation_id]))
 
         # Reserve the same donation again
-        response = self.client.get(reverse('reserve_donation', args=[self.donation.donation_id]))
+        response = self.client.get(
+            reverse("reserve_donation", args=[self.donation.donation_id])
+        )
 
         # Check if the reservation was successful
         self.assertEqual(response.status_code, 302)  # Redirect after success
-        self.assertRedirects(response, reverse('recipient_dashboard'))
+        self.assertRedirects(response, reverse("recipient_dashboard"))
 
         # Check if the order was created and the quantity was incremented
-        order = Order.objects.filter(user=self.user, donation=self.donation, order_status='pending').first()
+        order = Order.objects.filter(
+            user=self.user, donation=self.donation, order_status="pending"
+        ).first()
         self.assertIsNotNone(order)
         self.assertEqual(order.order_quantity, 2)  # Should be incremented to 2
 
         # Check if the donation quantity was reduced correctly
         self.donation.refresh_from_db()
-        self.assertEqual(self.donation.quantity, 3)  # Initially 5, reduced by 2 reservations
+        self.assertEqual(
+            self.donation.quantity, 3
+        )  # Initially 5, reduced by 2 reservations
 
         # Check if the success message was returned
         messages = list(get_messages(response.wsgi_request))
-        self.assertEqual(len(messages), 2)  # should have two messages for the two reservations
+        self.assertEqual(
+            len(messages), 2
+        )  # should have two messages for the two reservations
         self.assertEqual(str(messages[0]), "Donation reserved successfully.")
 
     def test_reserve_donation_only_increments_pending_orders(self):
@@ -208,22 +228,30 @@ class ReserveDonationTest(TestCase):
             user=self.user,
             order_quantity=1,
             order_status="picked_up",  # Status is not 'pending'
-            active=True
+            active=True,
         )
 
         # Try to reserve the same donation
-        response = self.client.get(reverse('reserve_donation', args=[self.donation.donation_id]))
+        response = self.client.get(
+            reverse("reserve_donation", args=[self.donation.donation_id])
+        )
 
         # Check if the reservation was successful
         self.assertEqual(response.status_code, 302)  # Redirect after success
-        self.assertRedirects(response, reverse('recipient_dashboard'))
+        self.assertRedirects(response, reverse("recipient_dashboard"))
 
         # Check if a new order was created instead of modifying the existing one
-        orders = Order.objects.filter(user=self.user, donation=self.donation).order_by('order_created_at')
-        self.assertEqual(orders.count(), 2)  # Two orders: one with 'picked_up' and one new 'pending'
-        pending_order = orders.filter(order_status='pending').first()
+        orders = Order.objects.filter(user=self.user, donation=self.donation).order_by(
+            "order_created_at"
+        )
+        self.assertEqual(
+            orders.count(), 2
+        )  # Two orders: one with 'picked_up' and one new 'pending'
+        pending_order = orders.filter(order_status="pending").first()
         self.assertIsNotNone(pending_order)
-        self.assertEqual(pending_order.order_quantity, 1)  # New pending order has quantity 1
+        self.assertEqual(
+            pending_order.order_quantity, 1
+        )  # New pending order has quantity 1
 
         # Check if the donation quantity was reduced correctly
         self.donation.refresh_from_db()

--- a/src/recipient_dashboard/tests.py
+++ b/src/recipient_dashboard/tests.py
@@ -116,7 +116,7 @@ class ReserveDonationTest(TestCase):
         # Set up SocialApp for allauth (required for login redirection)
         site = Site.objects.get_current()
         self.social_app = SocialApp.objects.create(
-            provider='google',  # or 'facebook', depending on your setup
+            provider='google',
             name='Test Google App',
             client_id='test-client-id',
             secret='test-secret',
@@ -173,3 +173,63 @@ class ReserveDonationTest(TestCase):
         # Ensure user is redirected to the login page
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, f'/accounts/login/?next=/recipient_dashboard/reserve/{self.donation.donation_id}/')
+    
+    def test_reserve_donation_increment_quantity(self):
+        """Test that reserving an existing donation increments the order quantity."""
+        # Reserve the donation for the first time
+        self.client.get(reverse('reserve_donation', args=[self.donation.donation_id]))
+
+        # Reserve the same donation again
+        response = self.client.get(reverse('reserve_donation', args=[self.donation.donation_id]))
+
+        # Check if the reservation was successful
+        self.assertEqual(response.status_code, 302)  # Redirect after success
+        self.assertRedirects(response, reverse('recipient_dashboard'))
+
+        # Check if the order was created and the quantity was incremented
+        order = Order.objects.filter(user=self.user, donation=self.donation, order_status='pending').first()
+        self.assertIsNotNone(order)
+        self.assertEqual(order.order_quantity, 2)  # Should be incremented to 2
+
+        # Check if the donation quantity was reduced correctly
+        self.donation.refresh_from_db()
+        self.assertEqual(self.donation.quantity, 3)  # Initially 5, reduced by 2 reservations
+
+        # Check if the success message was returned
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 2)  # should have two messages for the two reservations
+        self.assertEqual(str(messages[0]), "Donation reserved successfully.")
+
+    def test_reserve_donation_only_increments_pending_orders(self):
+        """Test that only pending orders are incremented, and not picked up or canceled orders."""
+        # Create a non-pending (e.g., picked_up) order for the user
+        Order.objects.create(
+            donation=self.donation,
+            user=self.user,
+            order_quantity=1,
+            order_status="picked_up",  # Status is not 'pending'
+            active=True
+        )
+
+        # Try to reserve the same donation
+        response = self.client.get(reverse('reserve_donation', args=[self.donation.donation_id]))
+
+        # Check if the reservation was successful
+        self.assertEqual(response.status_code, 302)  # Redirect after success
+        self.assertRedirects(response, reverse('recipient_dashboard'))
+
+        # Check if a new order was created instead of modifying the existing one
+        orders = Order.objects.filter(user=self.user, donation=self.donation).order_by('order_created_at')
+        self.assertEqual(orders.count(), 2)  # Two orders: one with 'picked_up' and one new 'pending'
+        pending_order = orders.filter(order_status='pending').first()
+        self.assertIsNotNone(pending_order)
+        self.assertEqual(pending_order.order_quantity, 1)  # New pending order has quantity 1
+
+        # Check if the donation quantity was reduced correctly
+        self.donation.refresh_from_db()
+        self.assertEqual(self.donation.quantity, 4)  # One reservation deducted
+
+        # Check if the success message was returned
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "Donation reserved successfully.")

--- a/src/recipient_dashboard/tests.py
+++ b/src/recipient_dashboard/tests.py
@@ -8,6 +8,7 @@ from django.contrib.messages import get_messages  # to capture messages
 from django.contrib.sites.models import Site
 from allauth.socialaccount.models import SocialApp
 
+
 class RecipientDashboardViewTests(TestCase):
     def setUp(self):
         # Creating a dummy user for testing

--- a/src/recipient_dashboard/tests.py
+++ b/src/recipient_dashboard/tests.py
@@ -1,10 +1,90 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
-from database.models import Donation, Organization
+from database.models import Donation, Organization, Order
+from django.utils import timezone # for pickup date being tomorrow in tests
+from datetime import timedelta # for pickup date being tomorrow in tests
+from django.contrib.messages import get_messages  # to capture messages
+from django.contrib.sites.models import Site
+from allauth.socialaccount.models import SocialApp
 
+# class RecipientDashboardViewTests(TestCase):
+#     def setUp(self):
+#         # Creating a dummy user for testing
+#         User = get_user_model()
+#         self.user = User.objects.create_user(username="testuser", password="testpass")
 
-class RecipientDashboardViewTests(TestCase):
+#         # Logging in the user
+#         self.client.login(username="testuser", password="testpass")
+
+#         # Create an organization for donations
+#         self.organization = Organization.objects.create(
+#             organization_name="Team 5 Test Organization",
+#             type="restaurant",
+#             address="123 Test St",
+#             zipcode=12345,
+#             contact_number="1234567890",
+#             email="test@example.com",
+#             website="http://test.org",
+#             active=True,
+#         )
+
+#         # Create active donations for testing
+#         self.donation1 = Donation.objects.create(
+#             organization_id=self.organization,
+#             food_item="Biryani",
+#             quantity=10,
+#             pickup_by="2024-10-15",
+#             active=True,
+#         )
+#         self.donation2 = Donation.objects.create(
+#             organization_id=self.organization,
+#             food_item="Shawarma",
+#             quantity=5,
+#             pickup_by="2024-10-15",
+#             active=True,
+#         )
+
+#     def test_recipient_dashboard_status_code(self):
+#         """
+#         Test that the recipient dashboard view returns a 200 OK status.
+#         """
+#         response = self.client.get(reverse("recipient_dashboard"))
+#         self.assertEqual(response.status_code, 200)
+
+#     def test_recipient_dashboard_template_used(self):
+#         """
+#         Test that the correct template is used for the recipient dashboard.
+#         """
+#         response = self.client.get(reverse("recipient_dashboard"))
+#         self.assertTemplateUsed(response, "recipient_dashboard/dashboard.html")
+
+#     def test_recipient_dashboard_active_donations(self):
+#         """
+#         Test that the context contains only active donations.
+#         """
+#         response = self.client.get(reverse("recipient_dashboard"))
+#         self.assertIn("donations", response.context)
+#         self.assertEqual(
+#             len(response.context["donations"]), 2
+#         )  # Should include 2 active donations
+
+#     def test_recipient_dashboard_donations_content(self):
+#         """
+#         Test that the donations returned are as expected.
+#         """
+#         response = self.client.get(reverse("recipient_dashboard"))
+#         donation_items = [
+#             donation.food_item for donation in response.context["donations"]
+#         ]
+#         self.assertIn("Biryani", donation_items)
+#         self.assertIn("Shawarma", donation_items)
+#         self.assertNotIn(
+#             "Pasta", donation_items
+#         )  # Checking if a non-listed item is checked or not
+
+class ReserveDonationTest(TestCase):
+
     def setUp(self):
         # Creating a dummy user for testing
         User = get_user_model()
@@ -12,69 +92,84 @@ class RecipientDashboardViewTests(TestCase):
 
         # Logging in the user
         self.client.login(username="testuser", password="testpass")
-
-        # Create an organization for donations
+        
+        # Create an organization
         self.organization = Organization.objects.create(
-            organization_name="Team 5 Test Organization",
+            organization_name="Test Organization",
             type="restaurant",
             address="123 Test St",
             zipcode=12345,
             contact_number="1234567890",
             email="test@example.com",
-            website="http://test.org",
-            active=True,
+            active=True
         )
-
-        # Create active donations for testing
-        self.donation1 = Donation.objects.create(
-            organization_id=self.organization,
-            food_item="Biryani",
-            quantity=10,
-            pickup_by="2024-10-15",
-            active=True,
-        )
-        self.donation2 = Donation.objects.create(
-            organization_id=self.organization,
-            food_item="Shawarma",
+        
+        # Create a donation
+        self.donation = Donation.objects.create(
+            organization=self.organization,
+            food_item="Test Food",
             quantity=5,
-            pickup_by="2024-10-15",
-            active=True,
+            pickup_by=timezone.now() + timedelta(days=1),
+            active=True
         )
 
-    def test_recipient_dashboard_status_code(self):
-        """
-        Test that the recipient dashboard view returns a 200 OK status.
-        """
-        response = self.client.get(reverse("recipient_dashboard"))
-        self.assertEqual(response.status_code, 200)
+        # Set up SocialApp for allauth (required for login redirection)
+        site = Site.objects.get_current()
+        self.social_app = SocialApp.objects.create(
+            provider='google',  # or 'facebook', depending on your setup
+            name='Test Google App',
+            client_id='test-client-id',
+            secret='test-secret',
+        )
+        self.social_app.sites.add(site)
 
-    def test_recipient_dashboard_template_used(self):
-        """
-        Test that the correct template is used for the recipient dashboard.
-        """
-        response = self.client.get(reverse("recipient_dashboard"))
-        self.assertTemplateUsed(response, "recipient_dashboard/dashboard.html")
+    def test_reserve_donation_success(self):
+        """Test a successful donation reservation."""
+        response = self.client.get(reverse('reserve_donation', args=[self.donation.donation_id]))
 
-    def test_recipient_dashboard_active_donations(self):
-        """
-        Test that the context contains only active donations.
-        """
-        response = self.client.get(reverse("recipient_dashboard"))
-        self.assertIn("donations", response.context)
-        self.assertEqual(
-            len(response.context["donations"]), 2
-        )  # Should include 2 active donations
+        # Check if the reservation was successful
+        self.assertEqual(response.status_code, 302)  # Redirect after success
+        self.assertRedirects(response, reverse('recipient_dashboard'))
 
-    def test_recipient_dashboard_donations_content(self):
-        """
-        Test that the donations returned are as expected.
-        """
-        response = self.client.get(reverse("recipient_dashboard"))
-        donation_items = [
-            donation.food_item for donation in response.context["donations"]
-        ]
-        self.assertIn("Biryani", donation_items)
-        self.assertIn("Shawarma", donation_items)
-        self.assertNotIn(
-            "Pasta", donation_items
-        )  # Checking if a non-listed item is checked or not
+        # Check if the order was created
+        order = Order.objects.filter(user=self.user, donation=self.donation, order_status='pending').first()
+        self.assertIsNotNone(order)
+        self.assertEqual(order.order_quantity, 1)
+
+        # Check if the donation quantity was reduced
+        self.donation.refresh_from_db()
+        self.assertEqual(self.donation.quantity, 4)
+
+        # Check if the success message was returned
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "Donation reserved successfully.")
+
+    def test_reserve_donation_no_quantity(self):
+        """Test reservation when the donation is no longer available."""
+        self.donation.quantity = 0
+        self.donation.save()
+
+        response = self.client.get(reverse('reserve_donation', args=[self.donation.donation_id]))
+
+        # Check if it redirects back
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse('recipient_dashboard'))
+
+        # Ensure no order was created
+        order = Order.objects.filter(user=self.user, donation=self.donation).first()
+        self.assertIsNone(order)
+
+        # Check if the error message was returned
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "This donation is no longer available.")
+
+    def test_reserve_donation_not_logged_in(self):
+        """Test that a user must be logged in to reserve a donation."""
+        self.client.logout()
+        response = self.client.get(reverse('reserve_donation', args=[self.donation.donation_id]))
+
+        # Ensure user is redirected to the login page
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, f'/accounts/login/?next=/recipient_dashboard/reserve/{self.donation.donation_id}/')

--- a/src/recipient_dashboard/urls.py
+++ b/src/recipient_dashboard/urls.py
@@ -2,6 +2,6 @@ from django.urls import path
 from .views import recipient_dashboard, reserve_donation
 
 urlpatterns = [
-    path('reserve/<uuid:donation_id>/', reserve_donation, name='reserve_donation'),
+    path("reserve/<uuid:donation_id>/", reserve_donation, name="reserve_donation"),
     path("", recipient_dashboard, name="recipient_dashboard"),
 ]

--- a/src/recipient_dashboard/urls.py
+++ b/src/recipient_dashboard/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import recipient_dashboard
+from .views import recipient_dashboard, reserve_donation
 
 urlpatterns = [
+    path('reserve/<uuid:donation_id>/', reserve_donation, name='reserve_donation'),
     path("", recipient_dashboard, name="recipient_dashboard"),
 ]

--- a/src/recipient_dashboard/views.py
+++ b/src/recipient_dashboard/views.py
@@ -1,6 +1,7 @@
-from database.models import Donation
-from django.shortcuts import render
+from database.models import Donation, Order
+from django.shortcuts import get_object_or_404, render, redirect
 from django.contrib.auth.decorators import login_required
+from django.contrib import messages
 
 
 @login_required
@@ -9,3 +10,25 @@ def recipient_dashboard(request):
     return render(
         request, "recipient_dashboard/dashboard.html", {"donations": donations}
     )
+
+@login_required
+def reserve_donation(request, donation_id):
+    donation = get_object_or_404(Donation, pk=donation_id, active=True)
+    if donation.quantity <= 0:
+        messages.error(request, "This donation is no longer available.")
+        return redirect('recipient_dashboard')
+    
+    # Create new order
+    order = Order.objects.create(
+        donation=donation,
+        user=request.user,
+        order_quantity=1,  # In future : allow user to select quantity
+        order_status="pending"
+    )
+
+    # Reduce donation quantity
+    donation.quantity -= 1
+    donation.save()
+
+    messages.success(request, "Donation reserved successfully.")
+    return redirect('recipient_dashboard')

--- a/src/recipient_dashboard/views.py
+++ b/src/recipient_dashboard/views.py
@@ -11,17 +11,20 @@ def recipient_dashboard(request):
         request, "recipient_dashboard/dashboard.html", {"donations": donations}
     )
 
+
 @login_required
 def reserve_donation(request, donation_id):
     try:
         donation = get_object_or_404(Donation, pk=donation_id, active=True)
         if donation.quantity <= 0:
             messages.warning(request, "This donation is no longer available.")
-            return redirect('recipient_dashboard')
-        
+            return redirect("recipient_dashboard")
+
         # Check if the user has already reserved this donation
-        existing_order = Order.objects.filter(donation=donation, user=request.user, active=True, order_status='pending').first()
-        
+        existing_order = Order.objects.filter(
+            donation=donation, user=request.user, active=True, order_status="pending"
+        ).first()
+
         if existing_order:
             # Increment order quantity if an order exists
             existing_order.order_quantity += 1
@@ -33,15 +36,15 @@ def reserve_donation(request, donation_id):
                 donation=donation,
                 user=request.user,
                 order_quantity=1,  # In the future: allow user to select quantity
-                order_status='pending'
+                order_status="pending",
             )
             messages.success(request, "Donation reserved successfully.")
-        
+
         # Reduce donation quantity
         donation.quantity -= 1
         donation.save()
 
-        return redirect('recipient_dashboard')
-    except Exception as e:
-        messages.warning(request, 'Unable to reserve donation. Try again later.')
-        return redirect('recipient_dashboard')
+        return redirect("recipient_dashboard")
+    except Exception:
+        messages.warning(request, "Unable to reserve donation. Try again later.")
+        return redirect("recipient_dashboard")

--- a/src/recipient_dashboard/views.py
+++ b/src/recipient_dashboard/views.py
@@ -15,7 +15,7 @@ def recipient_dashboard(request):
 def reserve_donation(request, donation_id):
     donation = get_object_or_404(Donation, pk=donation_id, active=True)
     if donation.quantity <= 0:
-        messages.error(request, "This donation is no longer available.")
+        messages.warning(request, "This donation is no longer available.")
         return redirect('recipient_dashboard')
     
     # Create new order


### PR DESCRIPTION
# [Issue 43](https://github.com/gcivil-nyu-org/wed-fall24-team5/issues/43)

## Description

- Adds the ability to reserve donation
- Once a user selects "Reserve" on a donation:
  - Creates an `Order` in the database
  - Sends a pop-up notification if the user has successfully reserved (or a warning message if there was an error)
- If the user has already requested a given donation, it increments their existing reservation rather than creating a new Order
  -  This Pull Request _does not_ implement the ability to request more than 1 donation at once
- Adds testing
- To experiment with this, run the server on `localhost`, open `PGAdmin` and try to make reservations. You will see reservations made in the `database_orders` schema.

## Change Type (delete non-relevant options)

- 💡 New feature (non-breaking change which adds functionality)