### PR TITLE
add develop capabilities to branch name check

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -23,6 +23,12 @@ jobs:
           echo "Branch name: $BRANCH_NAME_LOWER"
 
           # Validate the lowercase branch name
+          if [[ "$BRANCH_NAME_LOWER" == "develop" ]]; then
+            echo "On develop branch. Validation passed."
+            exit 0
+          fi
+
+          # Validate the lowercase branch name
           if [[ ! "$BRANCH_NAME_LOWER" =~ ^(bugfix|feature|hotfix|chore|release|test|doc|refactor)/issue-[0-9]+[/-][a-z0-9_-]+$ ]]; then
             echo "Branch name $BRANCH_NAME_LOWER does not follow the required pattern: branch-type/issue-###/short-description"
             echo "branch-type must be one of: bugfix, feature, hotfix, chore, release, test, doc, refactor"


### PR DESCRIPTION
- Bypasses the branch name check if we are on `develop`
- This allows us to merge develop onto main