### PR TITLE
Maintain tab position 

### DIFF
--- a/src/donor_dashboard/templates/donor_dashboard/list.html
+++ b/src/donor_dashboard/templates/donor_dashboard/list.html
@@ -71,7 +71,7 @@
     <!--Tab Navigation Bar-->
     <div class="tabs is-centered is-toggle is-fullwidth">
         <ul>
-            <li class="is-active" id="active-tab">
+            <li id="active-tab">
                 <a>
                     <span>Active</span>
                 </a>

--- a/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
+++ b/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
@@ -30,14 +30,14 @@ Manage Organization
         <!-- Tab navigation -->
         <div class="tabs is-centered is-toggle is-fullwidth mt-3">
             <ul>
-                <li id="donations-tab" class="is-active"><a>Donations</a></li>
+                <li id="donations-tab"><a>Donations</a></li>
                 <li id="orders-tab"><a>Orders</a></li>
                 <li id="reviews-tab"><a>Reviews</a></li>
             </ul>
         </div>
 
         <!-- Content for List of Donations tab -->
-        <div id="donations-content">
+        <div id="donations-content" class="manage-tab">
             {% if status %}
                 <div class="buttons">
                     <button id="add-donation-button" class="button is-dark">Add Donation</button>
@@ -98,7 +98,7 @@ Manage Organization
         </div>
 
         <!-- Content for Orders Received tab -->
-        <div id="orders-content" class="is-hidden">
+        <div id="orders-content" class="is-hidden manage-tab">
             <h2 class="subtitle mt-3"><strong>All Orders</strong></h2>
             {% if orders %}
             <div class="table-container">
@@ -143,7 +143,7 @@ Manage Organization
         </div>
 
         <!-- Content for My Reviews tab -->
-        <div id="reviews-content" class="tab-content is-hidden">
+        <div id="reviews-content" class="tab-content is-hidden manage-tab">
             <h2 class="subtitle mt-3"><strong>My Reviews</strong></h2>
             {% if reviews %}
                 <div class="columns is-multiline is-variable is-3">

--- a/src/recipient_orders/templates/recipient_orders/orders.html
+++ b/src/recipient_orders/templates/recipient_orders/orders.html
@@ -58,7 +58,7 @@
         <h2 class="subtitle mt-3">Your reservations:</h2>
         <div class="tabs is-centered is-toggle is-fullwidth">
             <ul>
-                <li class="is-active" id="pending-tab">
+                <li id="pending-tab">
                     <a><span>Pending</span></a>
                 </li>
                 <li id="picked-up-tab">

--- a/src/recipient_orders/templates/recipient_orders/orders.html
+++ b/src/recipient_orders/templates/recipient_orders/orders.html
@@ -248,53 +248,6 @@
             {% endif %}
         </div>
     </div>
-    <script>
-    // Tab switching functionality
-    document.addEventListener('DOMContentLoaded', () => {
-        const tabs = document.querySelectorAll('.tabs ul li');
-        const orderLists = document.querySelectorAll('.order-list');
-
-        tabs.forEach((tab, index) => {
-            tab.addEventListener('click', () => {
-                tabs.forEach(t => t.classList.remove('is-active'));
-                orderLists.forEach(list => list.classList.add('is-hidden'));
-
-                tab.classList.add('is-active');
-                orderLists[index].classList.remove('is-hidden');
-            });
-        });
-        
-        // Modal functionality
-        const modal = document.getElementById('modifyOrderModal');
-        const closeButtons = modal.querySelectorAll('.delete, .modal-background');
-        
-        closeButtons.forEach(button => {
-            button.addEventListener('click', () => {
-                closeModifyModal();
-            });
-        });
-    });
-
-    // Modal functions
-    function openModifyModal(orderId, currentQuantity, availableQuantity, foodItem) {
-        const modal = document.getElementById('modifyOrderModal');
-        const maxAllowed = Math.min(3, parseInt(availableQuantity) + parseInt(currentQuantity));
-        
-        document.getElementById('order_id').value = orderId;
-        document.getElementById('current_quantity').value = currentQuantity;
-        document.getElementById('available_quantity').value = availableQuantity;
-        document.getElementById('food_item').value = foodItem;
-        document.getElementById('new_quantity').max = maxAllowed;
-        document.getElementById('max_allowed').textContent = maxAllowed;
-        document.getElementById('new_quantity').value = currentQuantity;
-
-        modal.classList.add('is-active');
-    }
-
-    function closeModifyModal() {
-        const modal = document.getElementById('modifyOrderModal');
-        modal.classList.remove('is-active');
-    }
-    </script>
+    <script src="{% static 'js/recipient_orders.js' %}"></script>
     <script src="{% static 'js/review_modal.js' %}"></script>
 {% endblock content %}

--- a/src/static/js/manage_organization.js
+++ b/src/static/js/manage_organization.js
@@ -1,32 +1,47 @@
 document.addEventListener("DOMContentLoaded", function () {
-    // Handle the tab switching logic
     const tabs = document.querySelectorAll('.tabs ul li');
-    const donationsContent = document.getElementById('donations-content');
-    const ordersContent = document.getElementById('orders-content');
-    const reviewsContent = document.getElementById('reviews-content');
+    const tabContents = document.querySelectorAll('.manage-tab');
 
-    function clearActiveTabs() {
-        tabs.forEach(tab => {
+    // Retrieve the active tab from localStorage or default to 'donations-tab'
+    const savedTab = localStorage.getItem('activeTab') || 'donations-tab';
+
+    // Check if the savedTab matches any tab, otherwise default to 'donations-tab'
+    let activeTabExists = false;
+    tabs.forEach((tab, index) => {
+        if (tab.id === savedTab) {
+            tab.classList.add('is-active');
+            tabContents[index].classList.remove('is-hidden');
+            activeTabExists = true;
+        } else {
             tab.classList.remove('is-active');
-        });
-        donationsContent.classList.add('is-hidden');
-        ordersContent.classList.add('is-hidden');
-        reviewsContent.classList.add('is-hidden');
+            tabContents[index].classList.add('is-hidden');
+        }
+    });
+
+    // If no matching tab was found, set 'donations-tab' as the default active tab and show its content
+    if (!activeTabExists) {
+        const defaultTab = document.getElementById('donations-tab');
+        const defaultContent = document.getElementById('donations-content');
+
+        if (defaultTab && defaultContent) {
+            defaultTab.classList.add('is-active');
+            defaultContent.classList.remove('is-hidden');
+        }
     }
 
-    // Add event listeners for the tabs
-    tabs.forEach(tab => {
-        tab.addEventListener('click', function () {
-            clearActiveTabs();
-            this.classList.add('is-active');
-            // Show the content based on the clicked tab's id
-            if (this.id === 'donations-tab') {
-                donationsContent.classList.remove('is-hidden');
-            } else if (this.id === 'orders-tab') {
-                ordersContent.classList.remove('is-hidden');
-            } else if (this.id === 'reviews-tab') {
-                reviewsContent.classList.remove('is-hidden');
-            }
+    // Add click event listeners to tabs
+    tabs.forEach((tab, index) => {
+        tab.addEventListener('click', () => {
+            // Remove active class from all tabs and hide all tab contents
+            tabs.forEach(t => t.classList.remove('is-active'));
+            tabContents.forEach(content => content.classList.add('is-hidden'));
+
+            // Activate the selected tab and show the corresponding content
+            tab.classList.add('is-active');
+            tabContents[index].classList.remove('is-hidden');
+
+            // Save the selected tab in localStorage
+            localStorage.setItem('activeTab', tab.id);
         });
     });
 

--- a/src/static/js/org_list_tabs.js
+++ b/src/static/js/org_list_tabs.js
@@ -1,15 +1,34 @@
-// Auto-dismiss notification after 10 seconds
 document.addEventListener('DOMContentLoaded', () => {
     const tabs = document.querySelectorAll('.tabs ul li');
-    const orderLists = document.querySelectorAll('.org-list');
+    const orgLists = document.querySelectorAll('.org-list');
 
+    // Retrieve the active tab from localStorage, defaulting to 'active-tab'
+    const savedTab = localStorage.getItem('activeTab') || 'active-tab';
+
+    // Set the active tab based on savedTab
+    tabs.forEach((tab, index) => {
+        if (tab.id === savedTab) {
+            tab.classList.add('is-active');
+            orgLists[index].classList.remove('is-hidden');
+        } else {
+            tab.classList.remove('is-active');
+            orgLists[index].classList.add('is-hidden');
+        }
+    });
+
+    // Add click event listeners to tabs
     tabs.forEach((tab, index) => {
         tab.addEventListener('click', () => {
+            // Remove active class from all tabs and hide all org lists
             tabs.forEach(t => t.classList.remove('is-active'));
-            orderLists.forEach(list => list.classList.add('is-hidden'));
+            orgLists.forEach(list => list.classList.add('is-hidden'));
 
+            // Add active class to the selected tab and show corresponding org list
             tab.classList.add('is-active');
-            orderLists[index].classList.remove('is-hidden');
+            orgLists[index].classList.remove('is-hidden');
+
+            // Save the selected tab in localStorage
+            localStorage.setItem('activeTab', tab.id);
         });
     });
 });

--- a/src/static/js/org_list_tabs.js
+++ b/src/static/js/org_list_tabs.js
@@ -2,19 +2,32 @@ document.addEventListener('DOMContentLoaded', () => {
     const tabs = document.querySelectorAll('.tabs ul li');
     const orgLists = document.querySelectorAll('.org-list');
 
-    // Retrieve the active tab from localStorage, defaulting to 'active-tab'
+    // Retrieve the active tab from localStorage or default to 'active-tab'
     const savedTab = localStorage.getItem('activeTab') || 'active-tab';
 
-    // Set the active tab based on savedTab
+    // Check if the savedTab matches any tab, otherwise default to 'active-tab'
+    let activeTabExists = false;
     tabs.forEach((tab, index) => {
         if (tab.id === savedTab) {
             tab.classList.add('is-active');
             orgLists[index].classList.remove('is-hidden');
+            activeTabExists = true;
         } else {
             tab.classList.remove('is-active');
             orgLists[index].classList.add('is-hidden');
         }
     });
+
+    // If no matching tab was found, set 'active-tab' as the default active tab and show its content
+    if (!activeTabExists) {
+        const defaultTab = document.getElementById('active-tab');
+        const defaultContent = document.querySelector('#active-tab.org-list');
+
+        if (defaultTab && defaultContent) {
+            defaultTab.classList.add('is-active');
+            defaultContent.classList.remove('is-hidden');
+        }
+    }
 
     // Add click event listeners to tabs
     tabs.forEach((tab, index) => {

--- a/src/static/js/recipient_orders.js
+++ b/src/static/js/recipient_orders.js
@@ -1,31 +1,43 @@
-
 document.addEventListener('DOMContentLoaded', () => {
-    // Tab switching functionality and remember what tab
-    // we are on by using localStorage
+    // Tab switching functionality and remember what tab we are on by using localStorage
     const tabs = document.querySelectorAll('.tabs ul li');
     const orderLists = document.querySelectorAll('.order-list');
 
-    // Get the active tab from localStorage, if available
+    // Get the active tab from localStorage or default to 'pending-tab'
     const savedTab = localStorage.getItem('activeTab') || 'pending-tab';
 
-    // Set the active tab based on savedTab
+    // Check if the savedTab matches any tab, otherwise default to 'pending-tab'
+    let activeTabExists = false;
     tabs.forEach((tab, index) => {
         if (tab.id === savedTab) {
             tab.classList.add('is-active');
             orderLists[index].classList.remove('is-hidden');
+            activeTabExists = true;
         } else {
             tab.classList.remove('is-active');
             orderLists[index].classList.add('is-hidden');
         }
     });
 
+    // If no matching tab was found, set 'pending-tab' as the default active tab and show its content
+    if (!activeTabExists) {
+        const defaultTab = document.getElementById('pending-tab');
+        const defaultContent = document.getElementById('pending-orders');
+
+        if (defaultTab && defaultContent) {
+            defaultTab.classList.add('is-active');
+            defaultContent.classList.remove('is-hidden');
+        }
+    }
+
     // Add click event listeners to tabs
     tabs.forEach((tab, index) => {
         tab.addEventListener('click', () => {
-            // Set active class on the selected tab and remove from others
+            // Remove active class from all tabs and hide all order lists
             tabs.forEach(t => t.classList.remove('is-active'));
             orderLists.forEach(list => list.classList.add('is-hidden'));
 
+            // Activate the selected tab and show the corresponding content
             tab.classList.add('is-active');
             orderLists[index].classList.remove('is-hidden');
 

--- a/src/static/js/recipient_orders.js
+++ b/src/static/js/recipient_orders.js
@@ -1,0 +1,67 @@
+
+document.addEventListener('DOMContentLoaded', () => {
+    // Tab switching functionality and remember what tab
+    // we are on by using localStorage
+    const tabs = document.querySelectorAll('.tabs ul li');
+    const orderLists = document.querySelectorAll('.order-list');
+
+    // Get the active tab from localStorage, if available
+    const savedTab = localStorage.getItem('activeTab') || 'pending-tab';
+
+    // Set the active tab based on savedTab
+    tabs.forEach((tab, index) => {
+        if (tab.id === savedTab) {
+            tab.classList.add('is-active');
+            orderLists[index].classList.remove('is-hidden');
+        } else {
+            tab.classList.remove('is-active');
+            orderLists[index].classList.add('is-hidden');
+        }
+    });
+
+    // Add click event listeners to tabs
+    tabs.forEach((tab, index) => {
+        tab.addEventListener('click', () => {
+            // Set active class on the selected tab and remove from others
+            tabs.forEach(t => t.classList.remove('is-active'));
+            orderLists.forEach(list => list.classList.add('is-hidden'));
+
+            tab.classList.add('is-active');
+            orderLists[index].classList.remove('is-hidden');
+
+            // Save the selected tab in localStorage
+            localStorage.setItem('activeTab', tab.id);
+        });
+    });
+
+    // Modal functionality
+    const modal = document.getElementById('modifyOrderModal');
+    const closeButtons = modal.querySelectorAll('.delete, .modal-background');
+
+    closeButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            closeModifyModal();
+        });
+    });
+});
+
+// Modal functions
+function openModifyModal(orderId, currentQuantity, availableQuantity, foodItem) {
+    const modal = document.getElementById('modifyOrderModal');
+    const maxAllowed = Math.min(3, parseInt(availableQuantity) + parseInt(currentQuantity));
+
+    document.getElementById('order_id').value = orderId;
+    document.getElementById('current_quantity').value = currentQuantity;
+    document.getElementById('available_quantity').value = availableQuantity;
+    document.getElementById('food_item').value = foodItem;
+    document.getElementById('new_quantity').max = maxAllowed;
+    document.getElementById('max_allowed').textContent = maxAllowed;
+    document.getElementById('new_quantity').value = currentQuantity;
+
+    modal.classList.add('is-active');
+}
+
+function closeModifyModal() {
+    const modal = document.getElementById('modifyOrderModal');
+    modal.classList.remove('is-active');
+}


### PR DESCRIPTION
# #177

## Description

- On pages with tabs, adds the current tab into `localStorage` so that when the page is refreshed (whether from form submission or user refresh), it navigates back onto the current tab
- Functionality enabled for the following pages:
  - Donor Dashboard (active vs inactive organizations)
  - Manage Organization
  - Recipient Orders

## Change Type (delete non-relevant options)

- 🧹 Chore (maintenance tasks that don't add new features or fix bugs)
