### PR TITLE
bug fix to remove psycopg2 from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,6 @@ oauthlib==3.2.2
 packaging==24.1
 pathspec==0.12.1
 platformdirs==4.3.6
-psycopg2==2.9.9
 psycopg2-binary==2.9.9
 pyasn1==0.6.1
 pyasn1_modules==0.4.1


### PR DESCRIPTION
# [Issue 202](https://github.com/gcivil-nyu-org/wed-fall24-team5/issues/202)

## Description
Remove the accidental re-addition of psycopg2

## Change Type

- 🪲 Bug fix (non-breaking change which fixes an issue)

## Dependencies

none
