### PR TITLE
fix ratings not displayed

### DIFF
--- a/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
+++ b/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
@@ -85,7 +85,11 @@ Manage Organization
             <div class="card pt-2 pb-2">
                 <div class="card-content">
                     <p class="heading">Average Rating</p>
+                    {% if rating is None %}
+                    <p class="title has-text-grey">No ratings</p>
+                    {% else %}
                     <p class="title">{{ rating|floatformat }} / 5</p>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/src/donor_dashboard/templates/donor_dashboard/statistics.html
+++ b/src/donor_dashboard/templates/donor_dashboard/statistics.html
@@ -46,7 +46,11 @@ Organization Statistics
                 <div class="card pt-2 pb-2">
                     <div class="card-content">
                         <p class="heading">Average Rating</p>
+                        {% if rating is None %}
+                        <p class="title has-text-grey">No ratings</p>
+                        {% else %}
                         <p class="title">{{ rating|floatformat }} / 5</p>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/src/recipient_dashboard/templates/recipient_dashboard/recipient_statistics.html
+++ b/src/recipient_dashboard/templates/recipient_dashboard/recipient_statistics.html
@@ -42,7 +42,11 @@ User Statistics
                 <div class="card pt-2 pb-2">
                     <div class="card-content">
                         <p class="heading">Average Rating Given</p>
+                        {% if rating is None %}
+                        <p class="title has-text-grey">No ratings</p>
+                        {% else %}
                         <p class="title">{{ rating }} / 5</p>
+                        {% endif %}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
# #243

## Description

- On the manage organization page, organization statistics, and recipient statistics pages, if there were no ratings, the display was incorrect
- If there are no ratings, we now display "No Ratings"

## Change Type (delete non-relevant options)

- 🪲 Bug fix (non-breaking change which fixes an issue)

