### PR TITLE
bugfix/issue-263/Manage_Organization_Delete_Organization_buttons_visi…

### DIFF
--- a/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
+++ b/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
@@ -26,23 +26,29 @@ Manage Organization
             <strong>{{ organization.organization_name }}</strong>
         </h2>
         <div id="organization-id" hidden>{{ organization.organization_id }}</div>
-        {% if owner_access %}
-        <div class="buttons is-inline-block">
-            <a href="{% url 'messaging:org_messaging_view' organization.organization_id %}"
-                class="button is-info">Messages</a>
-            <a href="{% url 'donor_dashboard:organization_details' organization.organization_id %}"
-                class="button is-info">Manage Organization</a>
-            <form id="delete-form" class="is-inline-block"
-                action="{% url 'donor_dashboard:delete_organization' organization.organization_id %}" method="post">
-                {% csrf_token %}
-                <button type="button" class="button is-danger" onclick="confirmDelete()">Make Organization Inactive </button>
-            </form>
-        </div>
+        {% if status %}
+            {% if owner_access %}
+            <div class="buttons is-inline-block">
+                <a href="{% url 'messaging:org_messaging_view' organization.organization_id %}"
+                    class="button is-info">Messages</a>
+                <a href="{% url 'donor_dashboard:organization_details' organization.organization_id %}"
+                    class="button is-info">Manage Organization</a>
+                <form id="delete-form" class="is-inline-block"
+                    action="{% url 'donor_dashboard:delete_organization' organization.organization_id %}" method="post">
+                    {% csrf_token %}
+                    <button type="button" class="button is-danger" onclick="confirmDelete()">Make Organization Inactive </button>
+                </form>
+            </div>
+            {% else %}
+            <div class="buttons is-inline-block">
+                <a href="{% url 'messaging:org_messaging_view' organization.organization_id %}"
+                    class="button is-info">Messages</a>
+            </div>
+            {% endif %}
         {% else %}
-        <div class="buttons is-inline-block">
-            <a href="{% url 'messaging:org_messaging_view' organization.organization_id %}"
-                class="button is-info">Messages</a>
-        </div>
+            <div class="media-right">
+                <span class="tag is-primary is-light is-medium mt-1">In Active</span>
+            </div>
         {% endif %}
     </div>
     <!-- Statistics -->


### PR DESCRIPTION
# [Issue 263](https://github.com/gcivil-nyu-org/wed-fall24-team5/issues/263)

## Description

Manage Organization Delete Organization buttons visible in inactive organization as well

## Change Type (delete non-relevant options)

- 🪲 Bug fix (non-breaking change which fixes an issue)

## Dependencies

- None
