### PR TITLE
correct labels in login and register page

### DIFF
--- a/src/accounts/templates/accounts/login.html
+++ b/src/accounts/templates/accounts/login.html
@@ -11,11 +11,11 @@
         <form method="post">
             {% csrf_token %}
             <div class="field">
-                <label class="label">{{ form.username.label_tag }}</label>
+                <label class="label">Email</label>
                 <div class="control">{{ form.username }}</div>
             </div>
             <div class="field">
-                <label class="label">{{ form.password.label_tag }}</label>
+                <label class="label">Password</label>
                 <div class="control">{{ form.password }}</div>
             </div>
             <div class="field mt-5">

--- a/src/accounts/templates/accounts/register.html
+++ b/src/accounts/templates/accounts/register.html
@@ -99,7 +99,7 @@
         <form method="post">
             {% csrf_token %}
             <div class="field">
-                <label class="label">{{ form.email.label_tag }}</label>
+                <label class="label">Email</label>
                 <div class="control">{{ form.email }}</div>
             </div>
             <div class="field is-grouped">


### PR DESCRIPTION
# [Issue 268](https://github.com/gcivil-nyu-org/wed-fall24-team5/issues/268)

## Description

Correct labels on login and register page

## Change Type (delete non-relevant options)

- 🪲 Bug fix (non-breaking change which fixes an issue)

## Dependencies

- None
