### PR TITLE
Fixed notifications for Messages Page which were showing up on other pages previously

### DIFF
--- a/src/messaging/templates/messaging_dashboard.html
+++ b/src/messaging/templates/messaging_dashboard.html
@@ -39,6 +39,7 @@
     </style>
     <div class="container mt-5">
         <div class="container-fluid">
+            {% include "partials/notifications.html" %}
             <div class="row">
                 <!-- Sidebar -->
                 <div class="col-md-3 bg-light p-3">


### PR DESCRIPTION
# [Issue #283](link-to-issue)

## Description
Fixed notifications for Messages Page which were showing up on other pages previously

## Change Type (delete non-relevant options)
- 🪲 Bug fix (non-breaking change which fixes an issue)