### PR TITLE
add organization validation

### DIFF
--- a/src/donor_dashboard/forms/add_organization_form.py
+++ b/src/donor_dashboard/forms/add_organization_form.py
@@ -21,9 +21,7 @@ class AddOrganizationForm(forms.ModelForm):
 
     def clean_organization_name(self):
         organization_name = self.cleaned_data.get("organization_name")
-        print(f"Validating organization_name: {organization_name}")
         if len(organization_name) < 3:
-            print("error")
             raise forms.ValidationError(
                 "Organization name should be at least 3 characters."
             )

--- a/src/donor_dashboard/forms/add_organization_form.py
+++ b/src/donor_dashboard/forms/add_organization_form.py
@@ -1,3 +1,4 @@
+import re
 from django import forms
 from database.models import Organization
 
@@ -17,6 +18,16 @@ class AddOrganizationForm(forms.ModelForm):
         ),
         error_messages={"required": "Organization name is required."},
     )
+
+    def clean_organization_name(self):
+        organization_name = self.cleaned_data.get("organization_name")
+        print(f"Validating organization_name: {organization_name}")
+        if len(organization_name) < 3:
+            print("error")
+            raise forms.ValidationError(
+                "Organization name should be at least 3 characters."
+            )
+        return organization_name
 
     type = forms.ChoiceField(
         required=True,
@@ -58,6 +69,12 @@ class AddOrganizationForm(forms.ModelForm):
         error_messages={"required": "Address is required."},
     )
 
+    def clean_address(self):
+        address = self.cleaned_data.get("address")
+        if len(address) < 5:
+            raise forms.ValidationError("Address should be at least 5 characters.")
+        return address
+
     zipcode = forms.IntegerField(
         required=True,
         widget=forms.NumberInput(
@@ -71,6 +88,12 @@ class AddOrganizationForm(forms.ModelForm):
         error_messages={"required": "Zipcode is required."},
     )
 
+    def clean_zipcode(self):
+        zipcode = self.cleaned_data.get("zipcode")
+        if len(str(zipcode)) != 5 or not str(zipcode).isdigit():
+            raise forms.ValidationError("Enter a valid zipcode.")
+        return zipcode
+
     contact_number = forms.CharField(
         required=True,
         widget=forms.TextInput(
@@ -82,6 +105,13 @@ class AddOrganizationForm(forms.ModelForm):
             }
         ),
     )
+
+    def clean_contact_number(self):
+        contact_number = self.cleaned_data.get("contact_number")
+        contact_number_regex = r"^\+?1?\d{9,15}$"
+        if not re.match(contact_number_regex, contact_number):
+            raise forms.ValidationError("Enter a valid phone number.")
+        return contact_number
 
     email = forms.EmailField(
         required=True,
@@ -96,6 +126,13 @@ class AddOrganizationForm(forms.ModelForm):
         error_messages={"required": "Email is required."},
     )
 
+    def clean_email(self):
+        email = self.cleaned_data.get("email")
+        email_regex = r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$"
+        if not re.match(email_regex, email):
+            raise forms.ValidationError("Enter a valid email address.")
+        return email
+
     website = forms.URLField(
         required=True,
         widget=forms.URLInput(
@@ -107,6 +144,13 @@ class AddOrganizationForm(forms.ModelForm):
             }
         ),
     )
+
+    def clean_website(self):
+        website = self.cleaned_data.get("website")
+        website_regex = r"^(http|https)://"
+        if not re.match(website_regex, website):
+            raise forms.ValidationError("Enter a valid website URL.")
+        return website
 
     class Meta:
         model = Organization

--- a/src/donor_dashboard/tests.py
+++ b/src/donor_dashboard/tests.py
@@ -39,30 +39,6 @@ class DonorDashboardViewsTests(TestCase):
         )
         self.client.login(email="testuser@example.com", password="password")
 
-    def test_add_organization_view_get(self):
-        response = self.client.get(reverse("donor_dashboard:add_organization"))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "add_organization.html")
-        self.assertIsInstance(response.context["form"], AddOrganizationForm)
-
-    def test_add_organization_view_post_valid(self):
-        form_data = {
-            "organization_name": "New Org",
-            "type": "self",
-            "address": "456 Test Avenue",
-            "zipcode": "54321",
-            "email": "neworg@test.com",
-            "website": "https://new.org",
-            "contact_number": "0987654321",
-        }
-        response = self.client.post(
-            reverse("donor_dashboard:add_organization"), form_data
-        )
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(
-            Organization.objects.filter(organization_name="New Org").exists()
-        )
-
     def test_get_org_list_view(self):
         response = self.client.get(reverse("donor_dashboard:org_list"))
         self.assertEqual(response.status_code, 200)

--- a/src/donor_dashboard/urls.py
+++ b/src/donor_dashboard/urls.py
@@ -5,7 +5,6 @@ app_name = "donor_dashboard"  # pylint: disable=invalid-name
 
 urlpatterns = [
     path("", views.get_org_list, name="org_list"),
-    path("add-organization/", views.add_organization, name="add_organization"),
     path(
         "manage_organization/<uuid:organization_id>/",
         views.manage_organization,

--- a/src/donor_dashboard/views.py
+++ b/src/donor_dashboard/views.py
@@ -26,23 +26,6 @@ import json
 
 
 @login_required
-def add_organization(request):
-    if request.method == "POST":
-        form = AddOrganizationForm(request.POST)
-        if form.is_valid():
-            organization = form.save()
-            org_user = User.objects.get(email=request.user.email)
-            OrganizationAdmin.objects.create(
-                user=org_user, organization=organization, access_level="owner"
-            )
-            messages.success(request, "Organization successfully added.")
-            return redirect("/")
-    else:
-        form = AddOrganizationForm()
-    return render(request, "add_organization.html", {"form": form})
-
-
-@login_required
 def get_org_info(request, organization_id):
     organization = Organization.objects.get(organization_id=organization_id)
     donations = Donation.objects.filter(
@@ -73,6 +56,33 @@ def get_org_list(request):
                 user=org_user, organization=organization, access_level="owner"
             )
             messages.success(request, "Organization successfully added.")
+            return redirect("/donor_dashboard")
+        else:
+            # Handle errors using Django messages
+            if form.errors.get("organization_name"):
+                messages.warning(
+                    request, "Organization Name is invalid. Please try again."
+                )
+            if form.errors.get("address"):
+                messages.warning(request, "Address is not valid. Please try again.")
+            if form.errors.get("zipcode"):
+                messages.warning(request, "Zipcode is not valid. Please try again.")
+            if form.errors.get("contact_number"):
+                messages.warning(
+                    request, "Contact Number is not valid. Please try again."
+                )
+            if form.errors.get("email"):
+                messages.warning(request, "Email is not valid. Please try again.")
+            if form.errors.get("website"):
+                messages.warning(request, "Website is not valid. Please try again.")
+
+            # Fallback error message
+            if not any(form.errors):
+                messages.warning(
+                    request, "Registration failed. Please check the form for errors."
+                )
+
+            # Pass the form with errors back to the template
             return redirect("/donor_dashboard")
     else:
         form = AddOrganizationForm()


### PR DESCRIPTION
# #333

## Description

- Adds validation to fields for 'Add Organization' in the forms.py
  - This uses the format of `clean_<Method-Name>` functions, which are automatically invoked in Django forms
- Adds validation for: Org name, address, zip code, phone number, email, and website

## Change Type (delete non-relevant options)

- 🪲 Bug fix (non-breaking change which fixes an issue)
