### PR TITLE
Display info for inactive organizations

### DIFF
--- a/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
+++ b/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
@@ -160,6 +160,7 @@ Manage Organization
                             </div>
                         </div>
                     </div>
+                    {% if donation.donation_status == "active" %}
                     <footer class="card-footer">
                         <a href="#" class="card-footer-item edit-link" data-id="{{ donation.donation_id }}"
                             data-food-item="{{ donation.food_item }}" data-quantity="{{ donation.quantity }}"
@@ -173,6 +174,7 @@ Manage Organization
                                 onclick="submitDeleteForm('{{ donation.donation_id }}')">Delete</a>
                         </form>
                     </footer>
+                    {% endif %}
                 </div>
             </div>
             {% endfor %}
@@ -232,6 +234,7 @@ Manage Organization
                                     {% endif %}
                                 </div>
                                 <br>
+                                {% if order.order_status == "pending" %}
                                 <a href="{% url 'donor_dashboard:manage_order' order.order_id %}"
                                     class="button is-small is-rounded is-info is-light is-outlined">
                                     {% if order.order_status == "pending" %}
@@ -240,6 +243,7 @@ Manage Organization
                                     Mark as pending
                                     {% endif %}
                                 </a>
+                                {% endif %}
                             </div>
                         </div>
                         {% endfor %}

--- a/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
+++ b/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
@@ -160,7 +160,7 @@ Manage Organization
                             </div>
                         </div>
                     </div>
-                    {% if donation.donation_status == "active" %}
+                    {% if donation.active %}
                     <footer class="card-footer">
                         <a href="#" class="card-footer-item edit-link" data-id="{{ donation.donation_id }}"
                             data-food-item="{{ donation.food_item }}" data-quantity="{{ donation.quantity }}"
@@ -234,7 +234,7 @@ Manage Organization
                                     {% endif %}
                                 </div>
                                 <br>
-                                {% if order.order_status == "pending" %}
+                                {% if order.active %}
                                 <a href="{% url 'donor_dashboard:manage_order' order.order_id %}"
                                     class="button is-small is-rounded is-info is-light is-outlined">
                                     {% if order.order_status == "pending" %}

--- a/src/donor_dashboard/views.py
+++ b/src/donor_dashboard/views.py
@@ -28,7 +28,9 @@ import json
 @login_required
 def get_org_info(request, organization_id):
     organization = Organization.objects.get(organization_id=organization_id)
-    donations = Donation.objects.filter(organization_id=organization.organization_id, active=True)
+    donations = Donation.objects.filter(
+        organization_id=organization.organization_id, active=True
+    )
     orders = Order.objects.filter(donation__organization=organization).prefetch_related(
         "donation"
     )
@@ -378,7 +380,9 @@ def statistics_orders_status(request, organization_id):
 @login_required
 def statistics_donations(request, organization_id):
     organization = Organization.objects.get(organization_id=organization_id)
-    donations = Donation.objects.filter(organization_id=organization.organization_id, active=True)
+    donations = Donation.objects.filter(
+        organization_id=organization.organization_id, active=True
+    )
     donations_data = (
         donations.annotate(date=TruncDate("created_at"))
         .values("date")

--- a/src/donor_dashboard/views.py
+++ b/src/donor_dashboard/views.py
@@ -281,7 +281,7 @@ def delete_organization(request, organization_id):
         organization = Organization.objects.get(organization_id=organization_id)
 
         # Set the active field in Donations to False for soft delete
-        donations = Donation.objects.filter(organization=organization, active=True)
+        donations = Donation.objects.filter(organization=organization)
         for donation in donations:
 
             # Set the active field in Orders to False for soft delete

--- a/src/donor_dashboard/views.py
+++ b/src/donor_dashboard/views.py
@@ -28,7 +28,7 @@ import json
 @login_required
 def get_org_info(request, organization_id):
     organization = Organization.objects.get(organization_id=organization_id)
-    donations = Donation.objects.filter(organization_id=organization.organization_id)
+    donations = Donation.objects.filter(organization_id=organization.organization_id, active=True)
     orders = Order.objects.filter(donation__organization=organization).prefetch_related(
         "donation"
     )
@@ -378,7 +378,7 @@ def statistics_orders_status(request, organization_id):
 @login_required
 def statistics_donations(request, organization_id):
     organization = Organization.objects.get(organization_id=organization_id)
-    donations = Donation.objects.filter(organization_id=organization.organization_id)
+    donations = Donation.objects.filter(organization_id=organization.organization_id, active=True)
     donations_data = (
         donations.annotate(date=TruncDate("created_at"))
         .values("date")

--- a/src/donor_dashboard/views.py
+++ b/src/donor_dashboard/views.py
@@ -306,7 +306,9 @@ def delete_organization(request, organization_id):
 @login_required
 def filter_statistics(request, organization_id):
     organization = Organization.objects.get(organization_id=organization_id)
-    donations = Donation.objects.filter(organization_id=organization.organization_id)
+    donations = Donation.objects.filter(
+        organization_id=organization.organization_id, active=True
+    )
     grouped_donations = (
         donations.annotate(month=ExtractMonth("created_at"))
         .values("month")

--- a/src/donor_dashboard/views.py
+++ b/src/donor_dashboard/views.py
@@ -138,7 +138,8 @@ def manage_organization(request, organization_id):
 
         # Fetch donations with related reviews
         donations = Donation.objects.filter(
-            organization_id=organization.organization_id
+            organization_id=organization.organization_id,
+            active=True,
         ).prefetch_related(
             Prefetch(
                 "userreview_set",
@@ -280,7 +281,7 @@ def delete_organization(request, organization_id):
         organization = Organization.objects.get(organization_id=organization_id)
 
         # Set the active field in Donations to False for soft delete
-        donations = Donation.objects.filter(organization=organization)
+        donations = Donation.objects.filter(organization=organization, active=True)
         for donation in donations:
 
             # Set the active field in Orders to False for soft delete

--- a/src/donor_dashboard/views.py
+++ b/src/donor_dashboard/views.py
@@ -28,9 +28,7 @@ import json
 @login_required
 def get_org_info(request, organization_id):
     organization = Organization.objects.get(organization_id=organization_id)
-    donations = Donation.objects.filter(
-        organization_id=organization.organization_id, active=True
-    )
+    donations = Donation.objects.filter(organization_id=organization.organization_id)
     orders = Order.objects.filter(donation__organization=organization).prefetch_related(
         "donation"
     )
@@ -138,17 +136,17 @@ def manage_organization(request, organization_id):
 
         # Fetch donations with related reviews
         donations = Donation.objects.filter(
-            organization_id=organization.organization_id, active=True
+            organization_id=organization.organization_id
         ).prefetch_related(
             Prefetch(
                 "userreview_set",
-                queryset=UserReview.objects.filter(active=True).order_by("modified_at"),
+                queryset=UserReview.objects.order_by("modified_at"),
             )
         )
 
         # Prefetch orders and dietary restrictions for each user
         orders = (
-            Order.objects.filter(donation__organization=organization, active=True)
+            Order.objects.filter(donation__organization=organization)
             .prefetch_related(
                 "donation",
                 "user",
@@ -308,9 +306,7 @@ def delete_organization(request, organization_id):
 @login_required
 def filter_statistics(request, organization_id):
     organization = Organization.objects.get(organization_id=organization_id)
-    donations = Donation.objects.filter(
-        organization_id=organization.organization_id, active=True
-    )
+    donations = Donation.objects.filter(organization_id=organization.organization_id)
     grouped_donations = (
         donations.annotate(month=ExtractMonth("created_at"))
         .values("month")
@@ -380,9 +376,7 @@ def statistics_orders_status(request, organization_id):
 @login_required
 def statistics_donations(request, organization_id):
     organization = Organization.objects.get(organization_id=organization_id)
-    donations = Donation.objects.filter(
-        organization_id=organization.organization_id, active=True
-    )
+    donations = Donation.objects.filter(organization_id=organization.organization_id)
     donations_data = (
         donations.annotate(date=TruncDate("created_at"))
         .values("date")
@@ -522,7 +516,7 @@ def modify_donation(request, donation_id):
 
 @login_required
 def delete_donation(request, donation_id):
-    donation = get_object_or_404(Donation, donation_id=donation_id, active=True)
+    donation = get_object_or_404(Donation, donation_id=donation_id)
     if request.method == "POST":
         donation.active = False  # Set the active field to False for soft delete
         donation.quantity = 0
@@ -544,7 +538,7 @@ def delete_donation(request, donation_id):
 
 @login_required
 def manage_order(request, order_id):
-    order = get_object_or_404(Order, order_id=order_id, active=True)
+    order = get_object_or_404(Order, order_id=order_id)
     donation = Donation.objects.get(donation_id=order.donation_id)
 
     order.order_status = "picked_up" if order.order_status == "pending" else "pending"


### PR DESCRIPTION
# #335 

## Description

- Displays donations and orders for an inactive organization
- Removes the ability for an inactive organization to edit their donations or orders

## Change Type (delete non-relevant options)

- 🪲 Bug fix (non-breaking change which fixes an issue)