### PR TITLE
Manage Org Bug Fix for Cancelled orders

### DIFF
--- a/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
+++ b/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
@@ -190,7 +190,7 @@ Manage Organization
     <!-- Content for Orders Received tab -->
     <div id="orders-content" class="is-hidden manage-tab">
         <div class="flex-container is-justify-content-space-between is-align-items-center mb-3">
-            <h2 class="subtitle mt-3"><strong>All Orders</strong></h2>
+            <h2 class="subtitle mt-3"><strong>Pending Orders</strong></h2>
         {% if status %}
         <div class="buttons">
             <a class="button is-dark" href="{% url 'donor_dashboard:download_orders' organization.organization_id %}">
@@ -244,26 +244,13 @@ Manage Organization
                                 <!-- Status and button at the bottom -->
                                 <div>
                                     <div class="tag is-info my-2 is-size-6 is-primary is-light">
-                                        Current Status:
-                                        {% if order.order_status == "pending" %}
-                                            Pending
-                                        {% elif order.order_status == "picked_up" %}
-                                            Complete
-                                        {% else %}
-                                            Cancelled
-                                        {% endif %}
+                                        Current Status: Pending
                                     </div>
                                     <br>
-                                    {% if order.active and order.order_status != "canceled" %}
                                     <a href="{% url 'donor_dashboard:manage_order' order.order_id %}"
                                         class="button is-small is-rounded is-info is-light is-outlined">
-                                        {% if order.order_status == "pending" %}
                                         Mark as complete
-                                        {% else %}
-                                        Mark as pending
-                                        {% endif %}
                                     </a>
-                                    {% endif %}
                                 </div>
                             </div>
                         {% endfor %}

--- a/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
+++ b/src/donor_dashboard/templates/donor_dashboard/manage_organization.html
@@ -220,50 +220,52 @@ Manage Organization
                 <div class="fixed-grid has-4-cols-desktop has-3-cols-tablet has-1-cols-mobile">
                     <div class="grid">
                         {% for order in group.list %}
-                        <div class="cell has-text-centered is-flex is-flex-direction-column is-justify-content-space-between" style="height: 100%">
-                            <div>
-                                <div class="is-size-5">{{ order.user.first_name }} {{ order.user.last_name }}</div>
-                                <div class="tag my-1 is-size-6 is-primary is-light">{{ order.order_quantity }} Reserved
+                            <div class="cell has-text-centered is-flex is-flex-direction-column is-justify-content-space-between" style="height: 100%">
+                                <div>
+                                    <div class="is-size-5">{{ order.user.first_name }} {{ order.user.last_name }}</div>
+                                    <div class="tag my-1 is-size-6 is-primary is-light">{{ order.order_quantity }} Reserved
+                                    </div>
+                                    <!-- Display dietary restrictions -->
+                                    <div class="mt-2">
+                                        <strong>Dietary Restrictions:</strong>
+                                        {% if order.user.dietary_restrictions %}
+                                        <ul>
+                                            {% for restriction in order.user.dietary_restrictions %}
+                                            <li>{{ restriction.restriction }}</li>
+                                            {% endfor %}
+                                        </ul>
+                                        {% else %}
+                                        <ul>
+                                            <li>None</li>
+                                        </ul>
+                                        {% endif %}
+                                    </div>
                                 </div>
-                                <!-- Display dietary restrictions -->
-                                <div class="mt-2">
-                                    <strong>Dietary Restrictions:</strong>
-                                    {% if order.user.dietary_restrictions %}
-                                    <ul>
-                                        {% for restriction in order.user.dietary_restrictions %}
-                                        <li>{{ restriction.restriction }}</li>
-                                        {% endfor %}
-                                    </ul>
-                                    {% else %}
-                                    <ul>
-                                        <li>None</li>
-                                    </ul>
+                                <!-- Status and button at the bottom -->
+                                <div>
+                                    <div class="tag is-info my-2 is-size-6 is-primary is-light">
+                                        Current Status:
+                                        {% if order.order_status == "pending" %}
+                                            Pending
+                                        {% elif order.order_status == "picked_up" %}
+                                            Complete
+                                        {% else %}
+                                            Cancelled
+                                        {% endif %}
+                                    </div>
+                                    <br>
+                                    {% if order.active and order.order_status != "canceled" %}
+                                    <a href="{% url 'donor_dashboard:manage_order' order.order_id %}"
+                                        class="button is-small is-rounded is-info is-light is-outlined">
+                                        {% if order.order_status == "pending" %}
+                                        Mark as complete
+                                        {% else %}
+                                        Mark as pending
+                                        {% endif %}
+                                    </a>
                                     {% endif %}
                                 </div>
                             </div>
-                            <!-- Status and button at the bottom -->
-                            <div>
-                                <div class="tag is-info my-2 is-size-6 is-primary is-light">
-                                    Current Status:
-                                    {% if order.order_status == "pending" %}
-                                    Pending
-                                    {% else %}
-                                    Complete
-                                    {% endif %}
-                                </div>
-                                <br>
-                                {% if order.active %}
-                                <a href="{% url 'donor_dashboard:manage_order' order.order_id %}"
-                                    class="button is-small is-rounded is-info is-light is-outlined">
-                                    {% if order.order_status == "pending" %}
-                                    Mark as complete
-                                    {% else %}
-                                    Mark as pending
-                                    {% endif %}
-                                </a>
-                                {% endif %}
-                            </div>
-                        </div>
                         {% endfor %}
                     </div>
                 </div>

--- a/src/donor_dashboard/views.py
+++ b/src/donor_dashboard/views.py
@@ -154,7 +154,9 @@ def manage_organization(request, organization_id):
 
         # Prefetch orders and dietary restrictions for each user
         orders = (
-            Order.objects.filter(donation__organization=organization)
+            Order.objects.filter(
+                donation__organization=organization, order_status="pending"
+            )
             .prefetch_related(
                 "donation",
                 "user",

--- a/src/donor_dashboard/views.py
+++ b/src/donor_dashboard/views.py
@@ -16,7 +16,7 @@ from django.contrib.auth.hashers import make_password
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.http import HttpResponse, JsonResponse
-from django.db.models import Avg, Count, F, Value, Case, When, IntegerField
+from django.db.models import Avg, Count, F, Value
 from django.db.models.functions import ExtractMonth, TruncDate, Coalesce
 from .helpers import validate_donation
 import csv

--- a/src/donor_dashboard/views.py
+++ b/src/donor_dashboard/views.py
@@ -166,20 +166,7 @@ def manage_organization(request, organization_id):
                     to_attr="dietary_restrictions",
                 ),
             )
-            .annotate(
-                status_order=Case(
-                    When(order_status="pending", then=Value(0)),
-                    When(order_status="picked_up", then=Value(1)),
-                    When(order_status="canceled", then=Value(2)),
-                    default=Value(99),
-                    output_field=IntegerField(),
-                )
-            )
-            .order_by(
-                "donation__pickup_by",
-                "donation__donation_id",
-                "status_order",
-            )
+            .order_by("-donation__pickup_by", "donation__donation_id")
         )
 
         # Process dietary restrictions to replace underscores and apply title case


### PR DESCRIPTION
# #319: [BUG] - Organization can change a canceled order into pending/complete

## Description

- Adjusted if-else logic on front-end in `manage-organization` to account for the `cancelled` status. 
- Added in improved sorting on back-end to sort by order status after sorting by donation_id and pickup_date
- New UI
  - ![Screenshot 2024-11-23 at 11 44 53 AM](https://github.com/user-attachments/assets/a420e6a8-135a-4213-acc3-9e4856e40c8a)

## Change Type (delete non-relevant options)

- 🪲 Bug fix (non-breaking change which fixes an issue)