### PR TITLE
Delete Community Drive Functionality

### DIFF
--- a/src/community_drives/templates/community_drives/list.html
+++ b/src/community_drives/templates/community_drives/list.html
@@ -110,6 +110,7 @@ Community Drives
         <div class="columns is-multiline is-variable">
             {% if drives %}
             {% for drive in drives %}
+            {% if drive.active %}
             <div class="column is-full">
                 <div class="card mb-5">
                     <div class="card-content">
@@ -139,6 +140,7 @@ Community Drives
                     </div>
                 </div>
             </div>
+            {% endif %}
             {% endfor %}
             {% else %}
             <p class="box">No active community drives to display.</p>
@@ -149,6 +151,7 @@ Community Drives
         <div class="columns is-multiline is-variable">
             {% if my_drives %}
             {% for drive in my_drives %}
+            {% if drive.active %}
             <div class="column is-full">
                 <div class="card mb-5">
                     <div class="card-content">
@@ -192,11 +195,20 @@ Community Drives
                                 <p class="is-size-4 has-text-weight-semibold">{{ drive.meal_progress }} / {{ drive.meal_target }}</p>
                                 <p>meals contributed</p>
                                 <a href="#" class="button is-primary mt-2">View Drive</a>
+                                <form
+                                    id="delete-drive-{{ drive.drive_id }}"
+                                    method="post"
+                                    action="{% url 'community_drives:delete_drive' drive.drive_id %}"
+                                >
+                                    {% csrf_token %}
+                                    <button href="#" class="button is-danger mt-2" onclick="confirmDeleteDrive('{{ drive.drive_id }}')">Delete Drive</button>
+                                </form>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
+            {% endif %}
             {% endfor %}
             {% else %}
             <p class="box">You have no active community drives.</p>

--- a/src/community_drives/tests.py
+++ b/src/community_drives/tests.py
@@ -250,4 +250,7 @@ class CommunityDriveViewTests(TestCase):
         )  # Expect redirect even if deletion fails
         messages = list(response.wsgi_request._messages)
         self.assertEqual(len(messages), 1)
-        self.assertEqual(str(messages[0]), "Failed to delete community drive.")
+        self.assertEqual(
+            str(messages[0]),
+            "Failed to delete community drive. Couldn't find the drive.",
+        )

--- a/src/community_drives/tests.py
+++ b/src/community_drives/tests.py
@@ -221,3 +221,27 @@ class CommunityDriveViewTests(TestCase):
         self.assertEqual(response.status_code, 405)
         self.assertEqual(response.json()["success"], False)
         self.assertEqual(response.json()["error"], "Invalid request method")
+
+    def test_delete_drive_success(self):
+        url = reverse("community_drives:delete_drive", kwargs={"drive_id": self.drive.drive_id})
+
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 302)  # Expect redirect after success
+        self.drive.refresh_from_db()
+        self.assertFalse(self.drive.active)  # Ensure the drive is deactivated
+        drive_orgs = DriveOrganization.objects.filter(drive=self.drive)
+        for drive_org in drive_orgs:
+            self.assertEqual(drive_org.meal_pledge, 0)
+            self.assertEqual(drive_org.volunteer_pledge, 0)
+
+    def test_delete_drive_nonexistent(self):
+        invalid_drive_id = uuid4()
+        url = reverse("community_drives:delete_drive", kwargs={"drive_id": invalid_drive_id})
+
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 302)  # Expect redirect even if deletion fails
+        messages = list(response.wsgi_request._messages)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "Failed to delete community drive.")

--- a/src/community_drives/tests.py
+++ b/src/community_drives/tests.py
@@ -223,7 +223,9 @@ class CommunityDriveViewTests(TestCase):
         self.assertEqual(response.json()["error"], "Invalid request method")
 
     def test_delete_drive_success(self):
-        url = reverse("community_drives:delete_drive", kwargs={"drive_id": self.drive.drive_id})
+        url = reverse(
+            "community_drives:delete_drive", kwargs={"drive_id": self.drive.drive_id}
+        )
 
         response = self.client.post(url)
 
@@ -237,11 +239,15 @@ class CommunityDriveViewTests(TestCase):
 
     def test_delete_drive_nonexistent(self):
         invalid_drive_id = uuid4()
-        url = reverse("community_drives:delete_drive", kwargs={"drive_id": invalid_drive_id})
+        url = reverse(
+            "community_drives:delete_drive", kwargs={"drive_id": invalid_drive_id}
+        )
 
         response = self.client.post(url)
 
-        self.assertEqual(response.status_code, 302)  # Expect redirect even if deletion fails
+        self.assertEqual(
+            response.status_code, 302
+        )  # Expect redirect even if deletion fails
         messages = list(response.wsgi_request._messages)
         self.assertEqual(len(messages), 1)
         self.assertEqual(str(messages[0]), "Failed to delete community drive.")

--- a/src/community_drives/urls.py
+++ b/src/community_drives/urls.py
@@ -28,4 +28,9 @@ urlpatterns = [
         views.delete_participation,
         name="delete-participation",
     ),
+    path(
+        "delete-drive/<uuid:drive_id>/",
+        views.delete_drive,
+        name="delete_drive",
+    )
 ]

--- a/src/community_drives/urls.py
+++ b/src/community_drives/urls.py
@@ -32,5 +32,5 @@ urlpatterns = [
         "delete-drive/<uuid:drive_id>/",
         views.delete_drive,
         name="delete_drive",
-    )
+    ),
 ]

--- a/src/community_drives/views.py
+++ b/src/community_drives/views.py
@@ -1,3 +1,4 @@
+from datetime import timezone
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
@@ -254,3 +255,21 @@ def delete_participation(request, organization_id, drive_id):
     return JsonResponse(
         {"success": False, "error": "Invalid request method"}, status=405
     )
+
+def delete_drive(request, drive_id):
+    if request.method == "POST":
+        try:
+            drive = CommunityDrive.objects.get(drive_id=drive_id)
+            drive.active = False
+            drive.save()
+            for drive_org in DriveOrganization.objects.filter(drive=drive):
+                drive_org.meal_pledge = 0
+                drive_org.volunteer_pledge = 0
+                drive_org.modified_at = timezone.now()
+                drive_org.save()
+
+            messages.success(request, f"Community drive '{drive}' successfully deleted.")
+            return redirect("/community_drives")
+        except:
+            messages.error(request, "Failed to delete community drive.")
+            return redirect("/community_drives")

--- a/src/community_drives/views.py
+++ b/src/community_drives/views.py
@@ -274,5 +274,7 @@ def delete_drive(request, drive_id):
             )
             return redirect("/community_drives")
         except CommunityDrive.DoesNotExist:
-            messages.error(request, "Failed to delete community drive. Couldn't find the drive.")
+            messages.error(
+                request, "Failed to delete community drive. Couldn't find the drive."
+            )
             return redirect("/community_drives")

--- a/src/community_drives/views.py
+++ b/src/community_drives/views.py
@@ -256,6 +256,7 @@ def delete_participation(request, organization_id, drive_id):
         {"success": False, "error": "Invalid request method"}, status=405
     )
 
+
 def delete_drive(request, drive_id):
     if request.method == "POST":
         try:
@@ -268,8 +269,10 @@ def delete_drive(request, drive_id):
                 drive_org.modified_at = timezone.now()
                 drive_org.save()
 
-            messages.success(request, f"Community drive '{drive}' successfully deleted.")
+            messages.success(
+                request, f"Community drive '{drive}' successfully deleted."
+            )
             return redirect("/community_drives")
-        except:
-            messages.error(request, "Failed to delete community drive.")
+        except CommunityDrive.DoesNotExist:
+            messages.error(request, "Failed to delete community drive. Couldn't find the drive.")
             return redirect("/community_drives")

--- a/src/static/js/drive_list.js
+++ b/src/static/js/drive_list.js
@@ -89,7 +89,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.short-text').forEach(element => {
         const maxChars = 300;
         if (element.textContent.length > maxChars) {
-            element.textContent = element.textContent.slice(0, maxChars-3) + ' ...';
+            element.textContent = element.textContent.slice(0, maxChars - 3) + ' ...';
         }
     });
 });
@@ -109,6 +109,12 @@ document.addEventListener('DOMContentLoaded', () => {
 // function triggerFileUpload(donationId) {
 //     document.getElementById(`file-upload-${donationId}`).click();
 // }
+
+function confirmDeleteDrive(driveId) {
+    if (confirm('Are you sure you want to delete this drive?')) {
+        document.getElementById('delete-form-' + driveId).submit();
+    }
+}
 
 // Handle file upload and send to the server
 function uploadDriveImage(inputElement) {


### PR DESCRIPTION
# #382

## Description

- Implements functionality to delete (aka inactivate) a community drive
- Sets all pledges to 0
- Sets drive to inactive

## Change Type (delete non-relevant options)

- 💡 New feature (non-breaking change which adds functionality)