### PR TITLE
fix aspect ratio of images on recipient dashboard so donation entries are uniform

### DIFF
--- a/src/recipient_dashboard/templates/recipient_dashboard/dashboard.html
+++ b/src/recipient_dashboard/templates/recipient_dashboard/dashboard.html
@@ -143,8 +143,8 @@ Donation Dashboard
                             <div class="image-container has-text-centered">
                                 <!-- djlint:off -->
                                 <img src="data:image/jpeg;base64,{{ donation.image_data }}" alt="Default Image"
-                                    onerror="this.src='{% static 'default.png' %}';" class="image"
-                                    style="width: 150px; max-height: 80%; object-fit: cover; border-radius: 10px;">
+                                    onerror="this.src='{% static 'default.png' %}';" class="image is-square"
+                                    style="max-width: 150px; height: 100%; object-fit: cover; border-radius: 10px;">
                                 <!-- djlint:on -->
                             </div>
                         </div>


### PR DESCRIPTION
# Issue #379 

## Description

Make image aspect ratio on recipient dashboard square

## Change Type (delete non-relevant options)

- 🧹 Chore (maintenance tasks that don't add new features or fix bugs)

## Dependencies

- No dependencies
