### PR TITLE
fix 0 and negative available in quantity search

### DIFF
--- a/src/recipient_dashboard/forms.py
+++ b/src/recipient_dashboard/forms.py
@@ -79,10 +79,12 @@ class SearchDonationForm(forms.Form):
     min_quantity = forms.IntegerField(
         required=False,
         label="Quantity Available",
+        min_value=1,  # This enforces minimum value of 1
         widget=forms.NumberInput(
             attrs={
                 "class": "input",
-                "placeholder": "0",
+                "placeholder": "1",  # Updated placeholder to reflect minimum value
+                "min": "1",  # HTML5 validation for number input
                 "style": """
                 background-color: transparent;
                 border-color: #CCC;


### PR DESCRIPTION
# [Issue 388](https://github.com/gcivil-nyu-org/wed-fall24-team5/issues/388)

## Description

You can put negative or zero in the quantity search, it should be minimum of 1.
## Change Type (delete non-relevant options)

- 🪲 Bug fix (non-breaking change which fixes an issue)

## Dependencies

None
