### PR TITLE
Reduced number of significant figures

### DIFF
--- a/src/recipient_dashboard/templates/recipient_dashboard/recipient_statistics.html
+++ b/src/recipient_dashboard/templates/recipient_dashboard/recipient_statistics.html
@@ -46,7 +46,7 @@ User Statistics
                         {% if rating is None %}
                         <p class="title has-text-grey">No ratings</p>
                         {% else %}
-                        <p class="title">{{ rating }} / 5</p>
+                        <p class="title">{{ rating|floatformat:1 }} / 5</p>
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
# [Issue 390](https://github.com/gcivil-nyu-org/wed-fall24-team5/issues/390)

## Description

Limited the number of significant figures in average rating given, now its not ugly.

## Change Type (delete non-relevant options)

- 🪲 Bug fix (non-breaking change which fixes an issue)

